### PR TITLE
feat: 서비스에서 브로드캐스트 수신자 호출하여 하루 1번 (PM 11:59분에서 자정(다음날)으로 넘어갈 때) onRec…

### DIFF
--- a/app/src/main/java/com/example/ceedlive/dday/receiver/NotificationReceiver.java
+++ b/app/src/main/java/com/example/ceedlive/dday/receiver/NotificationReceiver.java
@@ -3,10 +3,21 @@ package com.example.ceedlive.dday.receiver;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
 import android.util.Log;
 
 public class NotificationReceiver extends BroadcastReceiver {
+
+    public interface ReceiveListener {
+        void onReceive(String action);
+    }
+
+    private static final String TAG = "NotificationReceiver";
+
+    private ReceiveListener listener;
+
+    public void callback(ReceiveListener listener) {
+        this.listener = listener;
+    }
 
     /**
      * 인텐트를 받으면 onReceive() 메소드가 자동으로 호출 된다.
@@ -18,20 +29,18 @@ public class NotificationReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         // TODO: This method is called when the BroadcastReceiver is receiving
 
-        Bundle bundle = intent.getExtras();
-        String strDate = bundle.getString("date");
-
-        Log.d("NotificationReceiver", "onReceive 호출");
-        Log.d("strDate", strDate);
+        Log.d(TAG, "onReceive 호출");
 
         if ( Intent.ACTION_TIME_TICK.equals( intent.getAction() ) ) {
             // 시간이 변경된 경우 해야 할 작업
-            Log.d("ACTION_TIME_TICK", "시간이 변경된 경우 해야 할 작업");
+            Log.d("NotificationReceiver", "ACTION_TIME_TICK: 시간이 변경된 경우 해야 할 작업");
+            listener.onReceive(Intent.ACTION_TIME_TICK);
         }
 
         if ( Intent.ACTION_DATE_CHANGED.equals( intent.getAction() ) ) {
             // 날짜가 변경된 경우 해야 할 작업
-            Log.d("NotificationReceiver", "날짜가 변경된 경우 해야 할 작업");
+            Log.d("NotificationReceiver", "ACTION_DATE_CHANGED: 날짜가 변경된 경우 해야 할 작업");
+            listener.onReceive(Intent.ACTION_DATE_CHANGED);
         }
 
         // an Intent broadcast.


### PR DESCRIPTION
- [x] 서비스에서 브로드캐스트 수신자 호출하여 하루 1번 (PM 11:59분에서 자정(다음날)으로 넘어갈 때) onReceive 메소드 안에서 알림 메시지 업데이트 할 수 있도록 로직 수정

구현방법  
1. 각각의 서비스마다 동적 브로드캐스트 등록 (registerReceiver)
    + onCreate 시점이나 onStartCommand 시점에 브로드캐스트 등록 시 2개 이상의 알림 메시지 업데이트 처리 불가 (구현 로직 상 버그)
2. 브로드캐스트 수신자 객체에 브로드캐스트 수신 시 리스너 인터페이스 추가
3. 서비스 처리 로직 부분에 리스너 인터페이스 구현 로직 추가  

resolved: #6 